### PR TITLE
PCWEB-9086 Typography의 태그명 동적 지정 방식 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remember_web/ui",
-  "version": "0.0.0-beta.27",
+  "version": "0.0.0-beta.32",
   "description": "Remember UI Components",
   "homepage": "https://dramancompany.github.io/rui/",
   "author": "Remember",

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { type TypographyStyle } from 'mixins/typography';
 import { TYPOGRAPHY_COMPONENT_MAP } from './const';
-import { getTypographyComponent } from './styles';
+import { StyledTypography } from './styles';
 import type { TypographyTagNames } from './types';
 
 export function Typography({
@@ -11,14 +11,14 @@ export function Typography({
   color,
   children,
 }: TypographyProps) {
-  const Component = getTypographyComponent(
-    tagName || TYPOGRAPHY_COMPONENT_MAP[variant]
-  );
-
   return (
-    <Component variant={variant} color={color}>
+    <StyledTypography
+      as={tagName || TYPOGRAPHY_COMPONENT_MAP[variant]}
+      variant={variant}
+      color={color}
+    >
       {children}
-    </Component>
+    </StyledTypography>
   );
 }
 

--- a/src/components/Typography/styles.ts
+++ b/src/components/Typography/styles.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-import { getTypographyStyles, type TypographyStyle } from 'mixins/typography';
-import type { TypographyTagNames } from './types';
 import { contents000 } from 'colors/v3';
+import { getTypographyStyles, type TypographyStyle } from 'mixins/typography';
 
-export const getTypographyComponent = (tagName: TypographyTagNames) => styled(
-  tagName
-)<{ variant?: TypographyStyle; color?: string }>`
+export const StyledTypography = styled.p<{
+  variant?: TypographyStyle;
+  color?: string;
+}>`
   ${({ variant = 'Body1_M' }) => getTypographyStyles(variant)}
   color: ${({ color = contents000 }) => color};
   margin: 0;


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- Typography의 태그명을 동적으로 지정하도록 구현한 내용 때문에 리렌더링할 때마다 새로운 styled-component 가 생성되는 이슈가 있음
  - -> Next.js에서 server/client side의 className mismatch 오류 발생
- 태그명에 따라 동적으로 styled-component를 생성하지 않고, as 애트리뷰트를 이용하는 방식으로 변경함

## 스크린샷 (Screenshot) 📷

- N/A

## 링크 (Links) 🔗

- [PCWEB-9086](https://dramancompany.atlassian.net/browse/PCWEB-9086)

## 기타 사항 (Etc) 🔖

- N/A

## 테스트 Checklist (Test Checklist) ✅

- N/A

## 희망 리뷰 완료 일 (Expected due date) ⏰

`2022.12.01. Thu`
