### PR TITLE
PCWEB-9280 360px breakpoint 추가, mobileSmallOnly 인자를 FlattenSimpleInterpolation으로 변경

### DIFF
--- a/src/mixins/breakpoints/const.ts
+++ b/src/mixins/breakpoints/const.ts
@@ -1,3 +1,5 @@
 export const mobileSizeBreak = 768;
 export const mobileSmallSizeBreak = 320;
 export const landingMobileSizeBreak = 1000;
+
+export const mobile360Break = 360;

--- a/src/mixins/breakpoints/index.ts
+++ b/src/mixins/breakpoints/index.ts
@@ -4,16 +4,25 @@ import {
   landingMobileSizeBreak,
   mobileSizeBreak,
   mobileSmallSizeBreak,
+  mobile360Break,
 } from './const';
 export * from './const';
 
 /** `max-width: ${mobileSmallSizeBreak}px` */
-export const mobileSmallOnly = (cssContent: string) => css`
+export const mobileSmallOnly = (cssContent: FlattenSimpleInterpolation) => css`
   @media only screen and (max-width: ${mobileSmallSizeBreak}px) {
     ${cssContent}
   }
 `;
 
+/** `max-width: ${mobile360Break}px` */
+export const mobile360SizeOnly = (
+  cssContent: FlattenSimpleInterpolation
+) => css`
+  @media only screen and (max-width: ${mobile360Break}px) {
+    ${cssContent}
+  }
+`;
 /** `max-width: ${mobileSizeBreak}px` */
 export const mobileOnly = (cssContent: FlattenSimpleInterpolation) => css`
   @media only screen and (max-width: ${mobileSizeBreak}px) {

--- a/src/mixins/breakpoints/index.ts
+++ b/src/mixins/breakpoints/index.ts
@@ -16,7 +16,7 @@ export const mobileSmallOnly = (cssContent: FlattenSimpleInterpolation) => css`
 `;
 
 /** `max-width: ${mobile360Break}px` */
-export const mobile360SizeOnly = (
+export const mobile360pxOnly = (
   cssContent: FlattenSimpleInterpolation
 ) => css`
   @media only screen and (max-width: ${mobile360Break}px) {

--- a/src/mixins/breakpoints/index.ts
+++ b/src/mixins/breakpoints/index.ts
@@ -16,9 +16,7 @@ export const mobileSmallOnly = (cssContent: FlattenSimpleInterpolation) => css`
 `;
 
 /** `max-width: ${mobile360Break}px` */
-export const mobile360pxOnly = (
-  cssContent: FlattenSimpleInterpolation
-) => css`
+export const mobile360pxOnly = (cssContent: FlattenSimpleInterpolation) => css`
   @media only screen and (max-width: ${mobile360Break}px) {
     ${cssContent}
   }


### PR DESCRIPTION
…olation로 받게 수정

## 작업 내용 (Content) 📝

-  디자인 팀과 논의 하에 추후 mobilesize 360px를 기준으로 디자인 작업을 할 예정이라 공통 모듈에 추가하는게 적합하다 판단하여 max-width 360px 기준의 breakpoint를 추가했습니다.
- 기존의 mobileSmallOnly 함수의 인자로 string을 받고 있었는데, 이를 FlattenSimpleInterpolation로 수정하였습니다

## 스크린샷 (Screenshot) 📷

- 필요하다면 스크린샷을 첨부해주세요.
- Attach a Screenshot if necessary.

## 링크 (Links) 🔗

- [JIRA 티켓 이름](https://dramancompany.atlassian.net/browse/PCWEB-)
- [개발 문서](https://dramancompany.atlassian.net/wiki/)
- [기획 문서](https://dramancompany.atlassian.net/wiki/)
- [디자인 문서](https://dramancompany.atlassian.net/wiki/)

## 기타 사항 (Etc) 🔖

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.
- Merge 전 필요한 작업이 있다면 적어주세요 (Checklist before merge)
- [ ] eg) Create XX table, Deploy app etc

## 테스트 Checklist (Test Checklist) ✅

- 꼭 테스트 해봐야하는 시나리오를 적어주세요
- [ ] eg) Test case

## 희망 리뷰 완료 일 (Expected due date) ⏰

`202X.X.X. Wed`
