### PR TITLE
PCWEB-9959 CompactPagination 무한 페이지네이션 옵션 추가

### DIFF
--- a/src/components/Common/Paginations/CompactPagination/CompactPagination.stories.tsx
+++ b/src/components/Common/Paginations/CompactPagination/CompactPagination.stories.tsx
@@ -9,6 +9,7 @@ const meta: ComponentMeta<typeof CompactPagination> = {
   args: {
     totalItemCount: 100,
     itemCountPerPage: 10,
+    infinite: true,
     className: 'CompactPagination',
   },
 };

--- a/src/components/Common/Paginations/CompactPagination/index.tsx
+++ b/src/components/Common/Paginations/CompactPagination/index.tsx
@@ -6,7 +6,7 @@ import {
   CompactPaginationContainer,
   CurrentPage,
 } from '../styles';
-import { DefaultPaginationProps } from '../types';
+import type { CompactPaginationProps } from '../types';
 import usePagination from '../usePagination';
 
 export function CompactPagination({
@@ -14,8 +14,9 @@ export function CompactPagination({
   totalItemCount = 0,
   onChangePage,
   itemCountPerPage,
+  infinite = false,
   className,
-}: DefaultPaginationProps) {
+}: CompactPaginationProps) {
   const {
     totalLastPage,
     prevPage,
@@ -32,8 +33,39 @@ export function CompactPagination({
   const iconColor = (disabled: boolean) =>
     disabled ? contents300 : contents000;
 
-  const onClickPrevPage = () => onChangePage(prevPage);
-  const onClickNextPage = () => onChangePage(nextPage);
+  const onClickPrevPage = () => {
+    const prevPageToGo =
+      activePage === 1 && infinite ? totalLastPage : prevPage;
+    onChangePage(prevPageToGo);
+  };
+
+  const onClickNextPage = () => {
+    const nextPageToGo =
+      activePage === totalLastPage && infinite ? 1 : nextPage;
+    onChangePage(nextPageToGo);
+  };
+
+  const hasOnlyOnePage = totalLastPage === 1;
+
+  const getArrowButtonDisabled = (disabled: boolean) => {
+    if (hasOnlyOnePage) {
+      return true;
+    }
+    if (infinite) {
+      return false;
+    }
+    return disabled;
+  };
+
+  const getArrowButtonColor = (disabled: boolean) => {
+    if (hasOnlyOnePage) {
+      return contents300;
+    }
+    if (infinite) {
+      return contents000;
+    }
+    return iconColor(disabled);
+  };
 
   return (
     <CompactPaginationContainer
@@ -42,25 +74,25 @@ export function CompactPagination({
       aria-label="페이지네이션"
     >
       <ArrowButton
-        disabled={isPrevPageDisabled}
+        disabled={getArrowButtonDisabled(isPrevPageDisabled)}
         onClick={onClickPrevPage}
         aria-label="이전 페이지로 이동"
       >
         <IconArrowLeftS
-          color={iconColor(isPrevPageDisabled)}
+          color={getArrowButtonColor(isPrevPageDisabled)}
           aria-hidden="true"
         />
       </ArrowButton>
-      <Flex gap="4px" style={{ minWidth: '44px' }}>
+      <Flex gap="4px" style={{ minWidth: '44px', userSelect: 'none' }}>
         <CurrentPage>{activePage}</CurrentPage>/ {totalLastPage}
       </Flex>
       <ArrowButton
-        disabled={isNextPageDisabled}
+        disabled={getArrowButtonDisabled(isNextPageDisabled)}
         onClick={onClickNextPage}
         aria-label="다음 페이지로 이동"
       >
         <IconArrowRightS
-          color={iconColor(isNextPageDisabled)}
+          color={getArrowButtonColor(isNextPageDisabled)}
           aria-hidden="true"
         />
       </ArrowButton>

--- a/src/components/Common/Paginations/types.ts
+++ b/src/components/Common/Paginations/types.ts
@@ -6,6 +6,10 @@ export interface DefaultPaginationProps {
   className?: string;
 }
 
+export interface CompactPaginationProps extends DefaultPaginationProps {
+  infinite?: boolean;
+}
+
 export interface PaginationProps extends DefaultPaginationProps {
   pageRangeDisplayed?: number;
   showFirstButton?: boolean;


### PR DESCRIPTION
## 작업 내용 (Content) 📝

- 무한 페이지네이션 infinite 옵션을 추가했습니다.
- totalpage가 1일 경우 양옆 Arrow 아이콘 disabled되도록 처리했습니다.

## 스크린샷 (Screenshot) 📷

https://user-images.githubusercontent.com/54617775/222627929-9388d745-e59c-41ca-84e7-0db33200c727.mov

## 링크 (Links) 🔗

- [PCWEB-9959](https://dramancompany.atlassian.net/browse/PCWEB-9959)

## 기타 사항 (Etc) 🔖

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.
- Merge 전 필요한 작업이 있다면 적어주세요 (Checklist before merge)
- [ ] eg) Create XX table, Deploy app etc

## 테스트 Checklist (Test Checklist) ✅

- 꼭 테스트 해봐야하는 시나리오를 적어주세요
- [ ] eg) Test case

## 희망 리뷰 완료 일 (Expected due date) ⏰

`202X.X.X. Wed`
